### PR TITLE
Update Info.pm

### DIFF
--- a/lib/SNMP/Info.pm
+++ b/lib/SNMP/Info.pm
@@ -1848,6 +1848,10 @@ sub device_type {
         $objtype = 'SNMP::Info::Layer2::NWSS2300'
             if (
             $desc =~ /^(Nortel\s)??Wireless\sSecurity\sSwitch\s23[568][012]\b/);
+	    
+	# Ubiquiti Networks, Inc. UniFi UAP-HD comes with IANA PEN 8072
+        $objtype = 'SNMP::Info::Layer2::Ubiquiti'
+            if ( $soid =~ /^\.?1\.3\.6\.1\.4\.1\.8072/ and $desc =~ /UAP/ );
 
         # Generic device classification based upon sysObjectID
         if (    ( $objtype eq 'SNMP::Info::Layer3' )


### PR DESCRIPTION
added device type override for Ubiquiti UniFi UAP-HD / UAP-AC-Pro wich comes with enterprise ID 8072 (net-snmp)